### PR TITLE
Update trainer skill cap based off modified skill instead of based skill

### DIFF
--- a/apps/openmw/mwgui/trainingwindow.cpp
+++ b/apps/openmw/mwgui/trainingwindow.cpp
@@ -80,7 +80,7 @@ namespace MWGui
 
         for (int i=0; i<ESM::Skill::Length; ++i)
         {
-            int value = npcStats.getSkill (i).getBase ();
+            int value = npcStats.getSkill (i).getModified ();
 
             skills.push_back(std::make_pair(i, value));
         }


### PR DESCRIPTION
http://en.uesp.net/wiki/Morrowind:Trainers

> If a Fortify Skill effect is cast on a trainer and makes that skill one of their three highest, it becomes one of the skills in which the trainer will offer training. Use this to make them train different skills and/or train to higher levels. For instance, casting a +100 Unarmored spell on any trainer will turn them into a master-level trainer in Unarmored for the duration of the spell.
